### PR TITLE
add .travis.yml 3.4버전 통과 안되는 문제해결

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 
 # command to install dependencies
 install:
+    - pip install six
     - pip install -r requirement/development.txt
 # command to run tests
 script:


### PR DESCRIPTION
import six 가 안되서
pip install six를 추가함