### PR TITLE
hotfix : quickslot potion info position modify

### DIFF
--- a/lucifer/lucifer/static/js/game/User_Interface/inventory.js
+++ b/lucifer/lucifer/static/js/game/User_Interface/inventory.js
@@ -1,6 +1,5 @@
 var testList = [];
 var alert_Equip, alert_Drop;
-var Inven_Potion_One_Info_test;
 
 function inventoryPreload(){
     Lucifer_Game.load.spritesheet('inven', '../../static/images/game/UI/Inventory/inventory.png', 354, 716);
@@ -61,8 +60,6 @@ function inventoryCreate(){
     alert_Equip.visible = false;
     alert_Equip.fixedToCamera = true;
     //---------------------------------------------------------------------------------------
-
-
 }
 
 //server-side로 데이터 실시간 전송
@@ -297,12 +294,18 @@ function useItem(){
             switch(selectedItem.name){
                 case '빨간물약':
                     quickSlot[0] = redPotionClone(727, 760);
+                    //Mansoo!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                    quickSlot[0].isQuickSlot = true;
                     break;
                 case '좋은물약':
                     quickSlot[0] = goodRedPotionClone(727, 760);
+                    //Mansoo!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                    quickSlot[0].isQuickSlot = true;
                     break;
                 case '최고의물약':
                     quickSlot[0] = bestRedPotionClone(727, 760);
+                    //Mansoo!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                    quickSlot[0].isQuickSlot = true;
                     break;
             }
             quickSlot[0].count = count;

--- a/lucifer/lucifer/static/js/game/User_Interface/inventory.js
+++ b/lucifer/lucifer/static/js/game/User_Interface/inventory.js
@@ -1,5 +1,6 @@
 var testList = [];
 var alert_Equip, alert_Drop;
+var Inven_Potion_One_Info_test;
 
 function inventoryPreload(){
     Lucifer_Game.load.spritesheet('inven', '../../static/images/game/UI/Inventory/inventory.png', 354, 716);
@@ -60,6 +61,8 @@ function inventoryCreate(){
     alert_Equip.visible = false;
     alert_Equip.fixedToCamera = true;
     //---------------------------------------------------------------------------------------
+
+
 }
 
 //server-side로 데이터 실시간 전송

--- a/lucifer/lucifer/static/js/game/User_Interface/itemStore.js
+++ b/lucifer/lucifer/static/js/game/User_Interface/itemStore.js
@@ -723,6 +723,10 @@ function buyItem() {
     }
     selectedItem = null;
     Item_Select_Frame.visible = false;
+
+    //Mansoo!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    quickSlot[0].isQuickSlot = false;
+    //---------------------------------------------------------------------------------------
     //퀘스트 검사
     playerQuestAdvence(1);
 }

--- a/lucifer/lucifer/static/js/game/item/item.js
+++ b/lucifer/lucifer/static/js/game/item/item.js
@@ -160,6 +160,13 @@ function redPotionClone(positionX, positionY){
     Inven_Potion_One_Info.anchor.setTo(0.5, 0.5);
     Inven_Potion_One_Info.fixedToCamera = true;
     Inven_Potion_One_Info.visible = false;
+
+    //Mansoo!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    Inven_Potion_One_Info_test = Lucifer_Game.add.sprite(720, 630, 'Potion_One_Info');
+    Inven_Potion_One_Info_test.anchor.setTo(0.5, 0.5);
+    Inven_Potion_One_Info_test.fixedToCamera = true;
+    Inven_Potion_One_Info_test.visible = false;
+
     //-----------------------------------------------------------------------------------
     return redPotionObject;
 }
@@ -192,6 +199,12 @@ function goodRedPotionClone(positionX, positionY){
     Inven_Potion_Two_Info.anchor.setTo(0.5, 0.5);
     Inven_Potion_Two_Info.fixedToCamera = true;
     Inven_Potion_Two_Info.visible = false;
+
+    //Mansoo!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    Inven_Potion_Two_Info_test = Lucifer_Game.add.sprite(720, 630, 'Potion_Two_Info');
+    Inven_Potion_Two_Info_test.anchor.setTo(0.5, 0.5);
+    Inven_Potion_Two_Info_test.fixedToCamera = true;
+    Inven_Potion_Two_Info_test.visible = false;
     //-----------------------------------------------------------------------------------
 
     return redPotionObject;
@@ -225,6 +238,12 @@ function bestRedPotionClone(positionX, positionY){
     Inven_Potion_Three_Info.anchor.setTo(0.5, 0.5);
     Inven_Potion_Three_Info.fixedToCamera = true;
     Inven_Potion_Three_Info.visible = false;
+
+    //Mansoo!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    Inven_Potion_Three_Info_test = Lucifer_Game.add.sprite(720, 630, 'Potion_Three_Info');
+    Inven_Potion_Three_Info_test.anchor.setTo(0.5, 0.5);
+    Inven_Potion_Three_Info_test.fixedToCamera = true;
+    Inven_Potion_Three_Info_test.visible = false;
     //-----------------------------------------------------------------------------------
 
     return redPotionObject;
@@ -402,28 +421,49 @@ function itemsCreate(){
 
 }
 
-function InvenonOverPotion(){
-    Inven_Potion_One_Info.visible = true;
+function InvenonOverPotion(isQuickSlot){
+    if(quickSlot[0].isQuickSlot == false){
+        Inven_Potion_One_Info.visible = true;
+    }else if(quickSlot[0].isQuickSlot == true){
+        Inven_Potion_One_Info_test.visible = true;
+    }
+
+    /*if(quickSlot[0].isQuickSlot == false)
+        {console.log(quickSlot[0].isQuickSlot);}
+    else
+        console.log(quickSlot[0]);
+    */
 }
 
 function InvenonOutPotion(){
     Inven_Potion_One_Info.visible = false;
+    Inven_Potion_One_Info_test.visible = false;
 }
 
 function InvenonOverPotion2(){
-    Inven_Potion_Two_Info.visible = true;
+    if(quickSlot[0].isQuickSlot == false){
+        Inven_Potion_Two_Info.visible = true;
+    }else if(quickSlot[0].isQuickSlot == true){
+        Inven_Potion_Two_Info_test.visible = true;
+    }
 }
 
 function InvenonOutPotion2(){
     Inven_Potion_Two_Info.visible = false;
+    Inven_Potion_Two_Info_test.visible = false;
 }
 
 function InvenonOverPotion3(){
-    Inven_Potion_Three_Info.visible = true;
+    if(quickSlot[0].isQuickSlot == false){
+        Inven_Potion_Three_Info.visible = true;
+    }else if(quickSlot[0].isQuickSlot == true){
+        Inven_Potion_Three_Info_test.visible = true;
+    }
 }
 
 function InvenonOutPotion3(){
     Inven_Potion_Three_Info.visible = false;
+    Inven_Potion_Three_Info_test.visible = false;
 }
 
 function InvenonOverSword(){


### PR DESCRIPTION
물약 구매 (isQuickSlot = false) -> 인벤토리 potion (isQuickSlot = false) -> 퀵슬롯 장착 (isQuickSlot = true)

현재 이 상태인데 

장착버튼을 누르면 퀵슬롯 포션이 isQuickSlot = true 로 변경되는 것까진 맞게 한거같은데 
문제는 이때 인벤토리에 포션 isQuickSlot 도 같이 true로 변경됨.

내가 건든 곳은 //Mansoo!!!!!!!!!!!!!! 로 주석을 달아놓았으니 Ctrl+F로 Mansoo를 검색해서 분석바람.

Item.js에 165번째줄 Inven_Potion_One_Info_test 이게 퀵슬롯 포션 정보 위치 생성해준 스프라이트임.

visible 가지고 놀기 방법임.